### PR TITLE
CI: Migrate to GitHub Actions

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!--- Provide a general summary of the issue in the Title above -->
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Context / environment
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+
+## Suggested Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!--- Provide a general summary of your changes in the Title above -->
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Where Has This Been Documented?
+<!--  Include where the changes made have been documented. -->
+<!--  This can simply be  a comment in the code or updating a docstring -->
+
+## Screenshots (if appropriate):
+
+## Pre-merge checklist
+- [ ] Code works interactively
+- [ ] Code contains descriptive comments
+- [ ] Test suite passes locally
+- [ ] Libraries are set to fixed versions and not ``Always Newest``
+- [ ] Code committed with ``pre-commit`` (alternatively ``pre-commit run --all-files``)

--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -1,0 +1,18 @@
+name: PCDS Standard Testing
+
+on:
+  push:
+  pull_request:
+  release:
+    types:
+      - published
+
+jobs:
+  standard:
+    uses: pcdshub/pcds-ci-helpers/.github/workflows/twincat-standard.yml@master
+    with:
+      # The workflow can be configured to look at a specific project directory, if
+      # desirable.  This defaults to the root of the repository (".").
+      project-root: "."
+      # Pattern (grep-compatible) of filenames to exclude in style checks.
+      style-exclude: ""

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks.git
+    rev: v4.4.0
+    hooks:
+    -   id: no-commit-to-branch
+    -   id: trailing-whitespace
+        files: \.(TcPOU|TcDUT|TcGVL)$
+
+-   repo: https://github.com/pcdshub/pre-commit-hooks.git
+    rev: v1.2.0
+    hooks:
+    -   id: twincat-leading-tabs-remover
+    -   id: twincat-lineids-remover
+    -   id: twincat-xml-format

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019, The Board of Trustees of the Leland Stanford Junior 
+Copyright (c) 2023, The Board of Trustees of the Leland Stanford Junior 
 University, through SLAC National Accelerator Laboratory (subject to receipt 
 of any required approvals from the U.S. Dept. of Energy). All rights reserved. 
 Redistribution and use in source and binary forms, with or without 


### PR DESCRIPTION
_Automated with [pcds-python-migration-tools](https://github.com/pcdshub/pcds-python-migration-tools)_

See the diff for the full list of changes.

* Enables GitHub Actions continuous integration for this repository
* Adds/updates SLAC ``LICENSE``.
* Removes documentation deployment Travis CI key(s).
* Updates pre-commit configuration.
* Adds files from the standard template, if not already in this repository:
    - ``.gitignore``
    - ``.gitattributes``
    - ``.pre-commit-config.yaml``
    - ``README.md``
    - Issue template
    - Pull request template
